### PR TITLE
Fixed the sample namespace to not forget about it

### DIFF
--- a/src/main/resources/releases/tackle-operator.yaml
+++ b/src/main/resources/releases/tackle-operator.yaml
@@ -1,7 +1,7 @@
 #apiVersion: v1
 #kind: Namespace
 #metadata:
-#  name: tackle-operator
+#  name: my-tackle-operator
 #---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
Accordingly to https://operatorhub.io/how-to-install-an-operator#What-happens-when-I-execute-the-'Install'-command-presented-in-the-pop-up?, entry #4:
```
A separate namespace, named after the Operator, in which the Operator following the scheme my-<operator-name>, in which the Operator and all the resources above
```