### PR TITLE
Add container-image Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,5 +122,12 @@
         <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.0-java11</quarkus.native.builder-image>
       </properties>
     </profile>
+    <profile>
+      <id>container-image</id>
+      <properties>
+        <quarkus.container-image.build>true</quarkus.container-image.build>
+        <quarkus.container-image.tag>${quarkus.application.version:latest}-${quarkus.package.type}</quarkus.container-image.tag>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Consistent with the `container-image` Maven profile we have in other Tackle projects