### PR TITLE
Tackle-190 Operator Integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>
       <artifactId>quarkus-operator-sdk</artifactId>
-      <version>1.8.4</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -47,6 +47,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,22 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-server-mock</artifactId>
-      <version>5.3.1</version>
-      <scope>test</scope>
+      <artifactId>kubernetes-client</artifactId>
+      <version>5.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <version>5.4.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.sundr</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-plugin.version>1.13.7.Final</quarkus-plugin.version>
-    <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
+    <quarkus-plugin.version>2.0.0.Final</quarkus-plugin.version>
+    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -54,11 +54,6 @@
       <artifactId>awaitility</artifactId>
       <version>4.0.3</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>5.4.1</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ io.tackle.operator.application-inventory.image=quay.io/konveyor/tackle-applicati
 io.tackle.operator.application-inventory.db.image=postgres:10.6
 io.tackle.operator.pathfinder.image=quay.io/konveyor/tackle-pathfinder:0.0.1-SNAPSHOT-native
 io.tackle.operator.pathfinder.db.image=postgres:10.6
+%test.quarkus.operator-sdk.crd.validate=false

--- a/src/main/resources/k8s/operator.yaml
+++ b/src/main/resources/k8s/operator.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: tackle-operator
     spec:
-      serviceAccount: tackle-operator
+      serviceAccountName: tackle-operator
       containers:
       - name: tackle-operator
         image: quay.io/{user}/tackle-operator:1.0.0-SNAPSHOT-native
@@ -51,7 +51,6 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: tackle-operator
-  namespace: tackle-operator
 roleRef:
   kind: Role
   name: tackle-operator

--- a/src/test/java/io/tackle/operator/KubernetesCrudRecorderDispatcher.java
+++ b/src/test/java/io/tackle/operator/KubernetesCrudRecorderDispatcher.java
@@ -1,0 +1,48 @@
+package io.tackle.operator;
+
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudAttributesExtractor;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesResponseComposer;
+import io.fabric8.mockwebserver.crud.ResponseComposer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/*
+This class will allow to check the requests made to the Kubernetes API
+in order to do the asserts
+*/
+public class KubernetesCrudRecorderDispatcher extends KubernetesCrudDispatcher {
+  private List<Request> requests = new ArrayList<>();
+
+  public KubernetesCrudRecorderDispatcher() {
+      this(Collections.emptyList());
+  }
+
+  public KubernetesCrudRecorderDispatcher(List<CustomResourceDefinitionContext> crdContexts) {
+    this(new KubernetesCrudAttributesExtractor(crdContexts), new KubernetesResponseComposer());
+  }
+
+  public KubernetesCrudRecorderDispatcher(KubernetesCrudAttributesExtractor attributeExtractor, ResponseComposer responseComposer) {
+    super(attributeExtractor, responseComposer);
+  }
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) {
+      requests.add(new Request(request.getPath(), request.getMethod(), request.getBody().clone().readUtf8()));
+      return super.dispatch(request);
+  }
+
+    // to avoid the ConcurrentModificationException that happens when reading the list inside a Stream but also adding elements to it
+  public List<Request> getRequests() {
+      return new ArrayList<Request>(requests);
+  }
+
+  public void setRequests(List<Request> requests) {
+      this.requests = requests;
+  }
+}

--- a/src/test/java/io/tackle/operator/KubernetesTestClientProducer.java
+++ b/src/test/java/io/tackle/operator/KubernetesTestClientProducer.java
@@ -1,0 +1,38 @@
+package io.tackle.operator;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.Context;
+import io.quarkus.arc.profile.IfBuildProfile;
+import okhttp3.mockwebserver.MockWebServer;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.HashMap;
+
+public class KubernetesTestClientProducer {
+    @Produces
+    @Singleton
+    @IfBuildProfile("test")
+    KubernetesClient makeDefaultClient(KubernetesMockServer server) {
+        return server.createClient();
+    }
+
+    @Produces
+    @Singleton
+    @IfBuildProfile("test")
+    KubernetesCrudRecorderDispatcher makeDispatcher() {
+        return new KubernetesCrudRecorderDispatcher( Collections.emptyList());
+    }
+
+    @Produces
+    @Singleton
+    @IfBuildProfile("test")
+    KubernetesMockServer makeKubernetesServer(KubernetesCrudRecorderDispatcher dispatcher) {
+        MockWebServer webServer = new MockWebServer();
+        KubernetesMockServer kubernetesServer = new KubernetesMockServer(new Context(), webServer, new HashMap<>(), dispatcher, false);
+        return kubernetesServer;
+    }
+
+}

--- a/src/test/java/io/tackle/operator/OperatorTest.java
+++ b/src/test/java/io/tackle/operator/OperatorTest.java
@@ -45,9 +45,10 @@ public class OperatorTest {
         tackleResource.getMetadata().setUid("uid: 4e4d714c-6d27-41e1-86df-4a58900ca5d0");
     }
 
-    @BeforeEach
-    public void clean() {
+    @Test
+    public void onAddCR_shouldServerReceiveExactCalls() {
         operator.start();
+
         NonNamespaceOperation<Tackle, KubernetesResourceList<Tackle>, Resource<Tackle>> resource = client.customResources(Tackle.class).inNamespace(testNamespace);
         if (resource.withName(testApp).get() != null) {
             resource.withName(testApp).delete();
@@ -61,10 +62,7 @@ public class OperatorTest {
             loadWindupResource();
         }
         resource.create(this.tackleResource);
-    }
 
-    @Test
-    public void onAddCR_shouldServerReceiveExactCalls() {
         Awaitility
             .await()
             .atMost(20, TimeUnit.SECONDS)

--- a/src/test/java/io/tackle/operator/OperatorTest.java
+++ b/src/test/java/io/tackle/operator/OperatorTest.java
@@ -1,0 +1,76 @@
+package io.tackle.operator;
+
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.quarkus.test.junit.QuarkusTest;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@QuarkusTest
+public class OperatorTest {
+    private static final String testCRDeployment = "/k8s/tackle/tackle.yaml";
+
+    private static final String testApp = "tackle-sample";
+
+    private static final String testNamespace = "test"; // hardcoded in the KubernetesMockServer.createClient
+
+    @Inject
+    KubernetesCrudRecorderDispatcher dispatcher;
+
+    @Inject
+    KubernetesClient client;
+
+    private Tackle tackleResource;
+
+    private void loadWindupResource() {
+        InputStream fileStream = this.getClass().getResourceAsStream(testCRDeployment);
+        tackleResource = Serialization.unmarshal(fileStream, Tackle.class);
+        tackleResource.getMetadata().setNamespace(testNamespace);
+        tackleResource.getMetadata().setUid("uid: 4e4d714c-6d27-41e1-86df-4a58900ca5d0");
+    }
+
+    @BeforeEach
+    public void clean() {
+        NonNamespaceOperation<Tackle, KubernetesResourceList<Tackle>, Resource<Tackle>> resource = client.customResources(Tackle.class).inNamespace(testNamespace);
+        if (resource.withName(testApp).get() != null) {
+            resource.withName(testApp).delete();
+            Awaitility
+                .await()
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertNull(resource.withName(testApp).get()));
+        }
+        dispatcher.setRequests(new ArrayList<Request>());
+        if (this.tackleResource == null) {
+            loadWindupResource();
+        }
+        resource.create(this.tackleResource);
+    }
+
+    @Test
+    public void onAddCR_shouldServerReceiveExactCalls() {
+       /* Awaitility
+            .await()
+            .atMost(20, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertEquals(1, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("ingress")).count());
+                assertEquals(4, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("persistentvolumeclaim")).count());
+                assertEquals(9, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("deployments") ).count());
+                assertEquals(9, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("service")).count());
+            });
+        */
+        Assert.assertFalse(false);
+    }
+
+}

--- a/src/test/java/io/tackle/operator/OperatorTest.java
+++ b/src/test/java/io/tackle/operator/OperatorTest.java
@@ -5,17 +5,18 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.wildfly.common.Assert;
 
 import javax.inject.Inject;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
@@ -28,6 +29,9 @@ public class OperatorTest {
 
     @Inject
     KubernetesCrudRecorderDispatcher dispatcher;
+
+    @Inject
+    Operator operator;
 
     @Inject
     KubernetesClient client;
@@ -43,6 +47,7 @@ public class OperatorTest {
 
     @BeforeEach
     public void clean() {
+        operator.start();
         NonNamespaceOperation<Tackle, KubernetesResourceList<Tackle>, Resource<Tackle>> resource = client.customResources(Tackle.class).inNamespace(testNamespace);
         if (resource.withName(testApp).get() != null) {
             resource.withName(testApp).delete();
@@ -60,7 +65,7 @@ public class OperatorTest {
 
     @Test
     public void onAddCR_shouldServerReceiveExactCalls() {
-       /* Awaitility
+        Awaitility
             .await()
             .atMost(20, TimeUnit.SECONDS)
             .untilAsserted(() -> {
@@ -69,8 +74,6 @@ public class OperatorTest {
                 assertEquals(9, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("deployments") ).count());
                 assertEquals(9, dispatcher.getRequests().stream().filter(e-> "POST".equalsIgnoreCase(e.method) && e.path.contains("service")).count());
             });
-        */
-        Assert.assertFalse(false);
     }
 
 }

--- a/src/test/java/io/tackle/operator/Request.java
+++ b/src/test/java/io/tackle/operator/Request.java
@@ -1,0 +1,13 @@
+package io.tackle.operator;
+
+public class Request {
+    String path;
+    String method;
+    String body;
+
+    public Request(String path, String method, String body) {
+        this.path = path;
+        this.method = method;
+        this.body = body;
+    }
+}


### PR DESCRIPTION
Issue : https://github.com/konveyor/tackle-operator/issues/38

This PR adds an integration test that verifies the number of operands created when a Tackle CR is created.

NOTE : Upgrades the application to Quarkus 2.0 , to avoid the issues with the Fabric8 MockServer and Kubernetes Client.
 