### PR TITLE
[TACKLE-330] - Reduce access token lifespan

### DIFF
--- a/src/main/resources/io/tackle/operator/deployers/templates/keycloak-configmap.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/keycloak-configmap.yaml
@@ -8,7 +8,7 @@ data:
       "notBefore" : 0,
       "revokeRefreshToken" : false,
       "refreshTokenMaxReuse" : 0,
-      "accessTokenLifespan" : 300,
+      "accessTokenLifespan" : 60,
       "accessTokenLifespanForImplicitFlow" : 900,
       "ssoSessionIdleTimeout" : 1800,
       "ssoSessionMaxLifespan" : 36000,


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-330

Reducing the `accessTokenLifespan` in order to shorten the propagation period of "A change in the user's roles" to "the roles within an access token".