### PR TITLE
Set predefined resource limits to all deployments within Tackle

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -22,8 +22,7 @@ jobs:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: ' --force --addons=ingress --cpus=5'
-          driver: docker
+          start args: ' --force --addons=ingress'
 
       - name: Setup Java 11
         uses: actions/setup-java@v2

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -22,7 +22,8 @@ jobs:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: ' --force --addons=ingress --cpus=max --container-runtime=cri-o'
+          start args: ' --force --addons=ingress --cpus=5'
+          driver: docker
 
       - name: Setup Java 11
         uses: actions/setup-java@v2

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -22,7 +22,7 @@ jobs:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: ' --force --addons=ingress'
+          start args: ' --force --addons=ingress --cpus=max'
 
       - name: Setup Java 11
         uses: actions/setup-java@v2

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -22,7 +22,7 @@ jobs:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes_version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: ' --force --addons=ingress --cpus=max'
+          start args: ' --force --addons=ingress --cpus=max --container-runtime=cri-o'
 
       - name: Setup Java 11
         uses: actions/setup-java@v2

--- a/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
@@ -91,3 +91,10 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 6
+          resources:            
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "250m"
+              memory: "1Gi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
@@ -91,10 +91,10 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 6
-          resources:            
-            limits:
-              cpu: "1"
-              memory: "1Gi"
-            requests:
-              cpu: "1"
-              memory: "1Gi"
+          # resources:            
+          #   limits:
+          #     cpu: "1"
+          #     memory: "1Gi"
+          #   requests:
+          #     cpu: "1"
+          #     memory: "1Gi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
@@ -96,5 +96,5 @@ spec:
               cpu: "1"
               memory: "1Gi"
             requests:
-              cpu: "250m"
+              cpu: "1"
               memory: "1Gi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/keycloak-deployment.yaml
@@ -91,10 +91,10 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 6
-          # resources:            
-          #   limits:
-          #     cpu: "1"
-          #     memory: "1Gi"
-          #   requests:
-          #     cpu: "1"
-          #     memory: "1Gi"
+          resources:            
+            limits:
+              cpu: "2"
+              memory: "1Gi"
+            requests:
+              cpu: "10m"
+              memory: "1Gi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
@@ -46,7 +46,13 @@ spec:
                 secretKeyRef:
                   name: ""
                   key: database-name
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: "750Mi"
+            requests:
+              cpu: "250m"
+              memory: "250Mi"
           livenessProbe:
             exec:
               command:

--- a/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
@@ -48,11 +48,11 @@ spec:
                   key: database-name
           resources:
             limits:
-              cpu: "1"
-              memory: "750Mi"
+              cpu: "500m"
+              memory: "512Mi"
             requests:
               cpu: "250m"
-              memory: "250Mi"
+              memory: "256Mi"
           livenessProbe:
             exec:
               command:

--- a/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/postgresql-deployment.yaml
@@ -51,8 +51,8 @@ spec:
               cpu: "500m"
               memory: "512Mi"
             requests:
-              cpu: "250m"
-              memory: "256Mi"
+              cpu: "10m"
+              memory: "64Mi"
           livenessProbe:
             exec:
               command:

--- a/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
@@ -84,5 +84,5 @@ spec:
               cpu: "500m"
               memory: "384Mi"
             requests:
-              cpu: "250m"
-              memory: "128Mi"
+              cpu: "10m"
+              memory: "64Mi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
@@ -79,10 +79,10 @@ spec:
             periodSeconds: 30
             successThreshold: 1
             timeoutSeconds: 10
-          resources:            
+          resources:
             limits:
               cpu: "500m"
-              memory: "1Gi"
+              memory: "384Mi"
             requests:
               cpu: "250m"
-              memory: "256Mi"
+              memory: "128Mi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
@@ -81,8 +81,8 @@ spec:
             timeoutSeconds: 10
           resources:            
             limits:
-              cpu: "1"
+              cpu: "500m"
               memory: "1Gi"
             requests:
               cpu: "250m"
-              memory: "250Mi"
+              memory: "256Mi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/rest-deployment.yaml
@@ -79,3 +79,10 @@ spec:
             periodSeconds: 30
             successThreshold: 1
             timeoutSeconds: 10
+          resources:            
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "250m"
+              memory: "250Mi"

--- a/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
@@ -55,7 +55,13 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "250m"
+              memory: "250Mi"
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always

--- a/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
@@ -57,11 +57,11 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              cpu: "1"
-              memory: "1Gi"
+              cpu: "500m"
+              memory: "512Mi"
             requests:
               cpu: "250m"
-              memory: "250Mi"
+              memory: "256Mi"
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always

--- a/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
+++ b/src/main/resources/io/tackle/operator/deployers/templates/ui-deployment.yaml
@@ -60,8 +60,8 @@ spec:
               cpu: "500m"
               memory: "512Mi"
             requests:
-              cpu: "250m"
-              memory: "256Mi"
+              cpu: "10m"
+              memory: "64Mi"
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: Always


### PR DESCRIPTION
Resolves: https://github.com/konveyor/tackle-operator/issues/104

## How to deploy the changes from this PR
- Check out this PR
- Create a container image based on the changes of this PR executing:

```shell
./mvnw clean package \
-Dquarkus.container-image.build=true \
-Dquarkus.container-image.registry=quay.io \
-Dquarkus.container-image.tag=issue-104
```
The previous command will create a container image called `quay.io/{myUsername}/tackle-operator:issue-104`

- Push your image to quay.io using the command:
```
docker push quay.io/{myUsername}/tackle-operator:issue-104
```
- Edit the file `src/main/resources/k8s/operator.yaml` and change the line `image: quay.io/{user}/tackle-operator:1.0.0-SNAPSHOT-native` by `image: quay.io/{myUsername}/tackle-operator:issue-104`. (Replace `{myUsername}` by your own username)

- Initialize Minikube and enable the ingress addon
- Execute the following commands:

```
kubectl create namespace tackle-operator
kubectl apply -f src/main/resources/k8s/crds/crds.yaml
kubectl create -n tackle-operator -f src/main/resources/k8s/operator.yaml
kubectl apply -f src/main/resources/k8s/tackle/tackle.yaml -n tackle-operator
```
- At this point you just need to wait for the deployments to be finished.