### PR TITLE
Change operator container image used during E2E test

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -49,7 +49,7 @@ jobs:
           cd ${{github.workspace}}/src/main/resources/k8s
           kubectl create namespace ${{env.tackle_ns}}
           kubectl apply -f crds/crds.yaml -n ${{env.tackle_ns}}
-          sed "s/{user}/konveyor/g" operator.yaml | kubectl apply -n ${{env.tackle_ns}} -f -
+          sed "s\{user}/tackle-operator:1.0.0-SNAPSHOT-native\konveyor/tackle-operator:test\g" operator.yaml | kubectl apply -n ${{env.tackle_ns}} -f -
 
       - name: Describe the operator
         run: kubectl describe deployment/tackle-operator -n ${{env.tackle_ns}}

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -51,9 +51,6 @@ jobs:
           kubectl apply -f crds/crds.yaml -n ${{env.tackle_ns}}
           sed "s\{user}/tackle-operator:1.0.0-SNAPSHOT-native\konveyor/tackle-operator:test\g" operator.yaml | kubectl apply -n ${{env.tackle_ns}} -f -
 
-      - name: Describe the operator
-        run: kubectl describe deployment/tackle-operator -n ${{env.tackle_ns}}
-
       - name: Verify operator
         run: kubectl wait deployment/tackle-operator --for condition=available --timeout=-1s -n ${{env.tackle_ns}}
 

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -49,7 +49,7 @@ jobs:
           cd ${{github.workspace}}/src/main/resources/k8s
           kubectl create namespace ${{env.tackle_ns}}
           kubectl apply -f crds/crds.yaml -n ${{env.tackle_ns}}
-          sed "s\{user}/tackle-operator:1.0.0-SNAPSHOT-native\konveyor/tackle-operator:test\g" operator.yaml | kubectl apply -n ${{env.tackle_ns}} -f -
+          sed "s\{user}/tackle-operator:1.0.0-SNAPSHOT-native\konveyor/tackle-operator:test\g" operator.yaml | sed "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" | kubectl apply -n ${{env.tackle_ns}} -f -
 
       - name: Verify operator
         run: kubectl wait deployment/tackle-operator --for condition=available --timeout=-1s -n ${{env.tackle_ns}}

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -51,6 +51,9 @@ jobs:
           kubectl apply -f crds/crds.yaml -n ${{env.tackle_ns}}
           sed "s/{user}/konveyor/g" operator.yaml | kubectl apply -n ${{env.tackle_ns}} -f -
 
+      - name: Describe the operator
+        run: kubectl describe deployment/tackle-operator -n ${{env.tackle_ns}}
+
       - name: Verify operator
         run: kubectl wait deployment/tackle-operator --for condition=available --timeout=-1s -n ${{env.tackle_ns}}
 

--- a/src/main/java/io/tackle/TackleOperator.java
+++ b/src/main/java/io/tackle/TackleOperator.java
@@ -19,6 +19,8 @@ public class TackleOperator implements QuarkusApplication {
 
     @Override
     public int run(String... args) throws Exception {
+        System.out.println("I'm going to exit now!");
+        System.exit(-1);
         operator.start();
         Quarkus.waitForExit();
         return 0;

--- a/src/main/java/io/tackle/TackleOperator.java
+++ b/src/main/java/io/tackle/TackleOperator.java
@@ -19,8 +19,6 @@ public class TackleOperator implements QuarkusApplication {
 
     @Override
     public int run(String... args) throws Exception {
-        System.out.println("I'm going to exit now!");
-        System.exit(-1);
         operator.start();
         Quarkus.waitForExit();
         return 0;


### PR DESCRIPTION
1. https://github.com/konveyor/tackle-operator/pull/118/commits/2f1e79f3edeb0691886b3f3d5389bb8f63412e9e introduces a bug in `TackleOperator` so that it exits immediately **BUT** it's [test execution](https://github.com/konveyor/tackle-operator/actions/runs/1607774654) worked successfully
2. https://github.com/konveyor/tackle-operator/pull/118/commits/fe9ed0303ecc5a1f6ece33e183e19f6383e00b04 adds the `tackle-operator` describe command (builds work fine as well) and the output of that command clearly shows the image is not the one with tag `test` as it should be (check next screenshot)
![Screenshot from 2021-12-21 18-06-45](https://user-images.githubusercontent.com/7288588/146975286-e006c218-a6d7-40b7-9927-edd5fc00e5e1.png)
3. https://github.com/konveyor/tackle-operator/pull/118/commits/50fc1422a1c15e9b1ce1ec4131829a2e6bca6de3 sets the proper image value in the `operator.yaml` file and the builds hang forever because the `Verify operator` step (i.e. `kubectl wait deployment/tackle-operator --for condition=available --timeout=-1s -n ${{env.tackle_ns}}`) waits forever since the operator exited immediately and it won't never be ready but the image is the expected one (check next screenshot)
![Screenshot from 2021-12-21 18-30-14](https://user-images.githubusercontent.com/7288588/146975706-313bd94c-968e-49f8-acfc-76b79a1791a4.png)
4. https://github.com/konveyor/tackle-operator/pull/118/commits/cf1584f8842df8e88cb075819f6c11bb65da0881 removed the bug added for debug and the describe command
5. https://github.com/konveyor/tackle-operator/pull/118/commits/6bc3b7bdd3ba2a05e41007767fa030835d22c55d introduces the proper value `imagePullPolicy` so that Minikube doesn't try to pull it but it uses the one provided during test execution
